### PR TITLE
Upgrade gdal + add arm support

### DIFF
--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -6,7 +6,7 @@
 # Note well: a very limited set of format drivers are included in these
 # wheels. See the GDAL configuration below for details.
 
-FROM quay.io/pypa/manylinux2014_aarch64
+FROM quay.io/pypa/manylinux2014_aarch64@sha256:c4fdb728c5b79b223b202269a8ae09282aec28d96d7da26d699cd9de0537a590
 
 RUN yum update -y && yum install -y curl libcurl-devel json-c-devel zlib-devel libtiff-devel postgresql-devel openjpeg-devel
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -6,9 +6,9 @@
 # Note well: a very limited set of format drivers are included in these
 # wheels. See the GDAL configuration below for details.
 
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux2014_aarch64
 
-RUN yum update -y && yum install -y curl libcurl-devel json-c-devel zlib-devel libtiff-devel postgresql-devel
+RUN yum update -y && yum install -y curl libcurl-devel json-c-devel zlib-devel libtiff-devel postgresql-devel openjpeg-devel
 
 # Install openssl
 RUN mkdir -p /src \
@@ -40,7 +40,7 @@ RUN mkdir -p /src \
     && curl -f -L -O http://download.osgeo.org/gdal/jasper-1.900.1.uuid.tar.gz \
     && tar xzf jasper-1.900.1.uuid.tar.gz \
     && cd /src/jasper-1.900.1.uuid \
-    && ./configure --disable-debug --enable-shared \
+    && ./configure --build=aarch64-unknown-linux-gnu --disable-debug --enable-shared \
     && make -j 4 \
     && make install \
     && rm -rf /src
@@ -56,19 +56,6 @@ RUN mkdir -p /src \
     && cmake .. \
     && cmake --build . \
     && cmake --install . \
-    && rm -rf /src
-
-# openjpeg
-RUN mkdir -p /src \
-    && cd /src \
-    && curl -f -L -O https://github.com/uclouvain/openjpeg/archive/v2.4.0.tar.gz \
-    && tar xzf v2.4.0.tar.gz \
-    && cd /src/openjpeg-2.4.0 \
-    && mkdir -p build \
-    && cd build \
-    && cmake .. -DBUILD_THIRDPARTY:BOOL=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
-    && make -j 4 install \
-    && make clean \
     && rm -rf /src
 
 # hdf5

--- a/Dockerfile.wheels
+++ b/Dockerfile.wheels
@@ -6,7 +6,7 @@
 # Note well: a very limited set of format drivers are included in these
 # wheels. See the GDAL configuration below for details.
 
-FROM quay.io/pypa/manylinux2014_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64@sha256:84497f1232480d78d96ada4cf4bfc11d8787cd7766765d34421eb56c9faff9c6
 
 RUN yum update -y && yum install -y curl libcurl-devel json-c-devel zlib-devel libtiff-devel postgresql-devel
 

--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,8 @@ wheel:
 	docker run -v `pwd`:/io storystream/gdal-wheelbuilder:gdal-3.5.1-x86_64
 	docker run -v `pwd`:/io storystream/gdal-wheelbuilder:gdal-3.5.1-arm64
 
+upload:
+	aws s3 cp wheels s3://storystream-gdal/wheels --recursive
 
+download:
+	aws s3 cp s3://storystream-gdal/wheels dist --recursive

--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,16 @@
 
 SHELL = /bin/bash
 
+all: build arm wheel
+
 build: Dockerfile.wheels build-linux-wheels.sh
-	docker build -f Dockerfile.wheels -t gdal-wheelbuilder:gdal-3.5.1-x86_64 .
+	docker build -f Dockerfile.wheels -t storystream/gdal-wheelbuilder:gdal-3.5.1-x86_64 .
 
 arm: Dockerfile.arm build-linux-wheels.sh
-	docker build -f Dockerfile.arm -t gdal-wheelbuilder:gdal-3.5.1-arm64 .
+	docker build -f Dockerfile.arm -t storystream/gdal-wheelbuilder:gdal-3.5.1-arm64 .
 
-wheel: build-linux-wheels.sh
-	docker run -v `pwd`:/io gdal-wheelbuilder
+wheel:
+	docker run -v `pwd`:/io storystream/gdal-wheelbuilder:gdal-3.5.1-x86_64
+	docker run -v `pwd`:/io storystream/gdal-wheelbuilder:gdal-3.5.1-arm64
+
+

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@
 
 SHELL = /bin/bash
 
-wheels: Dockerfile.wheels build-linux-wheels.sh
-	docker build -f Dockerfile.wheels -t gdal-wheelbuilder .
+build: Dockerfile.wheels build-linux-wheels.sh
+	docker build -f Dockerfile.wheels -t gdal-wheelbuilder:gdal-3.5.1-x86_64 .
+
+arm: Dockerfile.arm build-linux-wheels.sh
+	docker build -f Dockerfile.arm -t gdal-wheelbuilder:gdal-3.5.1-arm64 .
+
+wheel: build-linux-wheels.sh
 	docker run -v `pwd`:/io gdal-wheelbuilder

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ wheel:
 	docker run -v `pwd`:/io storystream/gdal-wheelbuilder:gdal-3.5.1-arm64
 
 upload:
-	aws s3 cp wheels s3://storystream-gdal/wheels --recursive
+	aws s3 cp wheels s3://storystream-gdal/wheels/gdal --recursive
 
 download:
 	aws s3 cp s3://storystream-gdal/wheels dist --recursive

--- a/README.md
+++ b/README.md
@@ -10,9 +10,13 @@ The template was directly derived from the [rasterio](https://github.com/mapbox/
 
 The building of the wheels is done via the docker container provided by the Python Packaging Authority as described [here](https://github.com/pypa/manylinux).
 
-To build, clone this repo, navigate to its root and run `make wheels`.  The container may take a while to build on first go, but once complete you should have a subdirectory called `wheels` filled with wheels containing the bindings.  
+To build, clone this repo, navigate to its root and run `make`.  The containers may take a while to build on first go, but once complete you should have a subdirectory called `wheels` filled with wheels containing the bindings.
 
-The resulting wheels have the gdal and proj data directories packaged up inside of them, but you can set the appropriate environment variables to use your own data directories. 
+The resulting wheels have the gdal and proj data directories packaged up inside of them, but you can set the appropriate environment variables to use your own data directories.
+
+## Publishing the Wheels
+
+Double check that the files in your `wheels` directory look and work correctly. Run `make upload` to publish the newly built wheels on S3 and rerun python-packages to publish the changes as a private package called `gdal` on CodeArtifact.
 
 ## Using the Wheels
 

--- a/build-linux-wheels.sh
+++ b/build-linux-wheels.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
 set -e
 
-GDAL_BUILD_PATH=/src/gdal-2.4.4/swig/python
+GDAL_BUILD_PATH=/src/gdal-3.5.1/swig/python
 ORIGINAL_PATH=$PATH
 UNREPAIRED_WHEELS=/tmp/wheels
-
-# Enable devtoolset-2 for C++11
-source /opt/rh/devtoolset-2/enable
 
 # Compile wheels
 pushd ${GDAL_BUILD_PATH}
 for PYBIN in /opt/python/*/bin; do
+    if [[ $PYBIN != *"cp311"* && $PYBIN != *"cp39"* ]]; then
+        # Only produce wheels for python versions we support
+        continue
+    fi
+
     export PATH=${PYBIN}:$ORIGINAL_PATH
     rm -rf build
     CFLAGS="-std=c++11" python setup.py bdist_wheel -d ${UNREPAIRED_WHEELS} || true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 cython        --only-binary cython
-numpy>=1.11   --only-binary numpy
+numpy>=1.19   --only-binary numpy

--- a/setup.py
+++ b/setup.py
@@ -7,22 +7,47 @@
 # Howard Butler hobu.inc@gmail.com
 
 
-gdal_version = '2.4.4'
+gdal_version = '3.5.1'
 
 import sys
-import shutil
 import os
 
 from glob import glob
+
+from setuptools.command.build_ext import build_ext
+from setuptools import setup
+from setuptools import find_packages
+from setuptools import Extension
+
+# If CXX is defined in the environment, it will be used to link the .so
+# but setuptools will be confused if it is made of several words like 'ccache g++'
+# and it will try to use only the first word.
+# See https://lists.osgeo.org/pipermail/gdal-dev/2016-July/044686.html
+# Note: in general when doing 'make', CXX will not be defined, unless it is defined as
+# an environment variable, but in that case it is the value of GDALmake.opt that
+# will be set, not the one from the environment that started 'make' !
+# If no CXX environment variable is defined, then the value of the CXX variable
+# in GDALmake.opt will not be set as an environment variable
+if 'CXX' in os.environ and os.environ['CXX'].strip().find(' ') >= 0:
+    if os.environ['CXX'].strip().startswith('ccache ') and os.environ['CXX'].strip()[len('ccache '):].find(' ') < 0:
+        os.environ['CXX'] = os.environ['CXX'].strip()[len('ccache '):]
+    else:
+        print('WARNING: 'CXX=%s' was defined in the environment and contains more than one word. Unsetting it since that is incompatible of setuptools' % os.environ['CXX'])
+        del os.environ['CXX']
+if 'CC' in os.environ and os.environ['CC'].strip().find(' ') >= 0:
+    if os.environ['CC'].strip().startswith('ccache ') and os.environ['CC'].strip()[len('ccache '):].find(' ') < 0:
+        os.environ['CC'] = os.environ['CC'].strip()[len('ccache '):]
+    else:
+        print('WARNING: 'CC=%s' was defined in the environment and contains more than one word. Unsetting it since that is incompatible of setuptools' % os.environ['CC'])
+        del os.environ['CC']
 
 # ---------------------------------------------------------------------------
 # Switches
 # ---------------------------------------------------------------------------
 
-HAVE_NUMPY=False
-HAVE_SETUPTOOLS = False
+HAVE_NUMPY = False
 BUILD_FOR_CHEESESHOP = False
-GNM_ENABLED = False
+GNM_ENABLED = True
 
 # ---------------------------------------------------------------------------
 # Default build options
@@ -33,6 +58,7 @@ include_dirs = ['../../port', '../../gcore', '../../alg', '../../ogr/', '../../o
 library_dirs = ['../../.libs', '../../']
 libraries = ['gdal']
 
+
 # ---------------------------------------------------------------------------
 # Helper Functions
 # ---------------------------------------------------------------------------
@@ -41,16 +67,9 @@ libraries = ['gdal']
 def get_numpy_include():
     if HAVE_NUMPY:
         return numpy.get_include()
-    else:
-        return '.'
+    return '.'
 
-def copy_data_tree(datadir, destdir):
-    try:
-        shutil.rmtree(destdir)
-    except OSError:
-        pass
-    shutil.copytree(datadir, destdir)
-            
+
 # ---------------------------------------------------------------------------
 # Imports
 # ---------------------------------------------------------------------------
@@ -61,93 +80,86 @@ try:
     # check version
     numpy_major = numpy.__version__.split('.')[0]
     if int(numpy_major) < 1:
-        print("numpy version must be > 1.0.0")
+        print('numpy version must be > 1.0.0')
         HAVE_NUMPY = False
     else:
-#        print ('numpy include', get_numpy_include())
-        if get_numpy_include() =='.':
-            print("numpy headers were not found!  Array support will not be enabled")
-            HAVE_NUMPY=False
+        #  print ('numpy include', get_numpy_include())
+        if get_numpy_include() == '.':
+            print('WARNING: numpy headers were not found!  Array support will not be enabled')
+            HAVE_NUMPY = False
 except ImportError:
+    print('WARNING: numpy not available!  Array support will not be enabled')
     pass
 
-fixer_names = [
-    'lib2to3.fixes.fix_import',
-    'lib2to3.fixes.fix_next',
-    'lib2to3.fixes.fix_renames',
-    'lib2to3.fixes.fix_unicode',
-    'lib2to3.fixes.fix_ws_comma',
-    'lib2to3.fixes.fix_xrange',
-]
-extra = {}
-try:
-    from setuptools import setup
-    from setuptools import Extension
-    HAVE_SETUPTOOLS = True
-except ImportError:
-    from distutils.core import setup, Extension
+class gdal_config_error(Exception):
+    pass
 
-    try:
-        from distutils.command.build_py import build_py_2to3 as build_py
-        from distutils.command.build_scripts import build_scripts_2to3 as build_scripts
-    except ImportError:
-        from distutils.command.build_py import build_py
-        from distutils.command.build_scripts import build_scripts
-    else:
-        build_py.fixer_names = fixer_names
-        build_scripts.fixer_names = fixer_names
-else:
-    if sys.version_info >= (3,):
-        from lib2to3.refactor import get_fixers_from_package
-
-        all_fixers = set(get_fixers_from_package('lib2to3.fixes'))
-        exclude_fixers = sorted(all_fixers.difference(fixer_names))
-
-        extra['use_2to3'] = True
-        extra['use_2to3_fixers'] = []
-        extra['use_2to3_exclude_fixers'] = exclude_fixers
-
-class gdal_config_error(Exception): pass
-
-
-from distutils.command.build_ext import build_ext
-from distutils.ccompiler import get_default_compiler
 
 def fetch_config(option, gdal_config='gdal-config'):
 
-    command = gdal_config + " --%s" % option
+    command = gdal_config + ' --%s' % option
 
+    import subprocess
+    command, args = command.split()[0], command.split()[1]
     try:
-        import subprocess
-        command, args = command.split()[0], command.split()[1]
-        from sys import version_info
-        if version_info >= (3,0,0):
-            try:
-                p = subprocess.Popen([command, args], stdout=subprocess.PIPE)
-            except OSError:
-                import sys
-                e = sys.exc_info()[1]
-                raise gdal_config_error(e)
-            r = p.stdout.readline().decode('ascii').strip()
-        else:
-            exec("""try:
-    p = subprocess.Popen([command, args], stdout=subprocess.PIPE)
-except OSError, e:
-    raise gdal_config_error, e""")
-            r = p.stdout.readline().strip()
-        p.stdout.close()
-        p.wait()
-
-    except ImportError:
-
-        import popen2
-
-        p = popen2.popen3(command)
-        r = p[0].readline().strip()
-        if not r:
-            raise Warning(p[2].readline())
+        p = subprocess.Popen([command, args], stdout=subprocess.PIPE)
+    except OSError:
+        e = sys.exc_info()[1]
+        raise gdal_config_error(e)
+    r = p.stdout.readline().decode('ascii').strip()
+    p.stdout.close()
+    p.wait()
 
     return r
+
+
+def supports_cxx11(compiler, compiler_flag=None):
+    ret = False
+    with open('gdal_python_cxx11_test.cpp', 'wt') as f:
+        f.write('''
+#if __cplusplus < 201103L
+#error 'C++11 required'
+#endif
+int main () { return 0; }''')
+        f.close()
+        extra_postargs = None
+        if compiler_flag:
+            extra_postargs = [compiler_flag]
+
+        if os.name == 'posix':
+            # Redirect stderr to /dev/null to hide any error messages
+            # from the compiler.
+            devnull = open(os.devnull, 'w')
+            oldstderr = os.dup(sys.stderr.fileno())
+            os.dup2(devnull.fileno(), sys.stderr.fileno())
+            try:
+                compiler.compile([f.name], extra_postargs=extra_postargs)
+                ret = True
+            except Exception:
+                pass
+            os.dup2(oldstderr, sys.stderr.fileno())
+            devnull.close()
+        else:
+            try:
+                compiler.compile([f.name], extra_postargs=extra_postargs)
+                ret = True
+            except Exception:
+                pass
+    os.unlink('gdal_python_cxx11_test.cpp')
+    if os.path.exists('gdal_python_cxx11_test.o'):
+        os.unlink('gdal_python_cxx11_test.o')
+    return ret
+
+###Based on: https://stackoverflow.com/questions/28641408/how-to-tell-which-compiler-will-be-invoked-for-a-python-c-extension-in-setuptool
+def has_flag(compiler, flagname):
+    import tempfile
+    with tempfile.NamedTemporaryFile('w', suffix='.cpp') as f:
+        f.write('int main (int argc, char **argv) { return 0; }')
+        try:
+            compiler.compile([f.name], extra_postargs=[flagname])
+        except Exception:
+            return False
+    return True
 
 class gdal_ext(build_ext):
 
@@ -155,7 +167,7 @@ class gdal_ext(build_ext):
     user_options = build_ext.user_options[:]
     user_options.extend([
         ('gdal-config=', None,
-        "The name of the gdal-config binary and/or a full path to it"),
+         'The name of the gdal-config binary and/or a full path to it'),
     ])
 
     def initialize_options(self):
@@ -164,29 +176,71 @@ class gdal_ext(build_ext):
         self.numpy_include_dir = get_numpy_include()
         self.gdaldir = None
         self.gdal_config = self.GDAL_CONFIG
-        self.already_raised_no_config_error = False
+        self.extra_cflags = []
+        self.parallel = True # Python 3.5 only
 
     def get_compiler(self):
-        return self.compiler or get_default_compiler()
+        return self.compiler or ('msvc' if os.name == 'nt' else 'unix')
 
     def get_gdal_config(self, option):
         try:
-            return fetch_config(option, gdal_config = self.gdal_config)
+            return fetch_config(option, gdal_config=self.gdal_config)
         except gdal_config_error:
             # If an error is thrown, it is possibly because
             # the gdal-config location given in setup.cfg is
             # incorrect, or possibly the default -- ../../apps/gdal-config
-            # We'll try one time to use the gdal-config that might be
-            # on the path. If that fails, we're done, however.
-            if not self.already_raised_no_config_error:
-                self.already_raised_no_config_error = True
+            # We'll try to use the gdal-config that might be on the path.
+            try:
                 return fetch_config(option)
+            except gdal_config_error:
+                msg = 'Could not find gdal-config. Make sure you have installed the GDAL native library and development headers.'
+                import sys
+                import traceback
+                traceback_string = ''.join(traceback.format_exception(*sys.exc_info()))
+                raise gdal_config_error(traceback_string + '\n' + msg)
+
+
+    def build_extensions(self):
+
+        # Add a -std=c++11 or similar flag if needed
+        ct = self.compiler.compiler_type
+        if ct == 'unix' and not supports_cxx11(self.compiler):
+            cxx11_flag = None
+            if supports_cxx11(self.compiler, '-std=c++11'):
+                cxx11_flag = '-std=c++11'
+            if cxx11_flag:
+                for ext in self.extensions:
+                    # gdalconst builds as a .c file
+                    if ext.name != 'osgeo._gdalconst':
+                        ext.extra_compile_args += [cxx11_flag]
+
+                    # Adding arch flags here if OS X and compiler is clang
+                    if sys.platform == 'darwin' and [int(x) for x in os.uname()[2].split('.')] >= [11, 0, 0]:
+                        # since MacOS X 10.9, clang no longer accepts -mno-fused-madd
+                        # extra_compile_args.append('-Qunused-arguments')
+                        clang_flag = '-Wno-error=unused-command-line-argument-hard-error-in-future'
+                        if has_flag(self.compiler, clang_flag):
+                            ext.extra_compile_args += [clang_flag]
+                        else:
+                            clang_flag = '-Wno-error=unused-command-line-argument'
+                            if has_flag(self.compiler, clang_flag):
+                                ext.extra_compile_args += [clang_flag]
+
+        build_ext.build_extensions(self)
 
     def finalize_options(self):
+        global include_dirs, library_dirs
+
         if self.include_dirs is None:
             self.include_dirs = include_dirs
+        # Needed on recent MacOSX
+        elif isinstance(self.include_dirs, str) and sys.platform == 'darwin':
+            self.include_dirs += ':' + ':'.join(include_dirs)
         if self.library_dirs is None:
             self.library_dirs = library_dirs
+        # Needed on recent MacOSX
+        elif isinstance(self.library_dirs, str) and sys.platform == 'darwin':
+            self.library_dirs += ':' + ':'.join(library_dirs)
         if self.libraries is None:
             if self.get_compiler() == 'msvc':
                 libraries.remove('gdal')
@@ -201,153 +255,133 @@ class gdal_ext(build_ext):
             return True
 
         self.gdaldir = self.get_gdal_config('prefix')
-        self.library_dirs.append(os.path.join(self.gdaldir,'lib'))
-        self.include_dirs.append(os.path.join(self.gdaldir,'include'))
+        self.library_dirs.append(os.path.join(self.gdaldir, 'lib'))
+        self.include_dirs.append(os.path.join(self.gdaldir, 'include'))
+
+        cflags = self.get_gdal_config('cflags')
+        if cflags:
+            self.extra_cflags = cflags.split()
+
+    def build_extension(self, ext):
+        # We override this instead of setting extra_compile_args directly on
+        # the Extension() instantiations below because we want to use the same
+        # logic to resolve the location of gdal-config throughout.
+        ext.extra_compile_args.extend(self.extra_cflags)
+        return build_ext.build_extension(self, ext)
 
 
 extra_link_args = []
 extra_compile_args = []
 
-if sys.platform == 'darwin' and [int(x) for x in os.uname()[2].split('.')] >= [11, 0, 0]:
-    # since MacOS X 10.9, clang no longer accepts -mno-fused-madd
-    #extra_compile_args.append('-Qunused-arguments')
-    os.environ['ARCHFLAGS'] = '-Wno-error=unused-command-line-argument-hard-error-in-future'
-
 gdal_module = Extension('osgeo._gdal',
                         sources=['extensions/gdal_wrap.cpp'],
-                        extra_compile_args = extra_compile_args,
-                        extra_link_args = extra_link_args)
+                        extra_compile_args=extra_compile_args,
+                        extra_link_args=extra_link_args)
 
 gdalconst_module = Extension('osgeo._gdalconst',
-                    sources=['extensions/gdalconst_wrap.c'],
-                    extra_compile_args = extra_compile_args,
-                    extra_link_args = extra_link_args)
+                             sources=['extensions/gdalconst_wrap.c'],
+                             extra_compile_args=extra_compile_args,
+                             extra_link_args=extra_link_args)
 
 osr_module = Extension('osgeo._osr',
-                    sources=['extensions/osr_wrap.cpp'],
-                    extra_compile_args = extra_compile_args,
-                    extra_link_args = extra_link_args)
+                       sources=['extensions/osr_wrap.cpp'],
+                       extra_compile_args=extra_compile_args,
+                       extra_link_args=extra_link_args)
 
 ogr_module = Extension('osgeo._ogr',
-                    sources=['extensions/ogr_wrap.cpp'],
-                    extra_compile_args = extra_compile_args,
-                    extra_link_args = extra_link_args)
+                       sources=['extensions/ogr_wrap.cpp'],
+                       extra_compile_args=extra_compile_args,
+                       extra_link_args=extra_link_args)
 
 
 array_module = Extension('osgeo._gdal_array',
-                    sources=['extensions/gdal_array_wrap.cpp'],
-                    extra_compile_args = extra_compile_args,
-                    extra_link_args = extra_link_args)
+                         sources=['extensions/gdal_array_wrap.cpp'],
+                         extra_compile_args=extra_compile_args,
+                         extra_link_args=extra_link_args)
 
 gnm_module = Extension('osgeo._gnm',
-                    sources=['extensions/gnm_wrap.cpp'],
-                    extra_compile_args = extra_compile_args,
-                    extra_link_args = extra_link_args)
+                       sources=['extensions/gnm_wrap.cpp'],
+                       extra_compile_args=extra_compile_args,
+                       extra_link_args=extra_link_args)
 
 ext_modules = [gdal_module,
-              gdalconst_module,
-              osr_module,
-              ogr_module]
-
-py_modules = ['gdal',
-              'ogr',
-              'osr',
-              'gdalconst']
+               gdalconst_module,
+               osr_module,
+               ogr_module]
 
 if os.path.exists('setup_vars.ini'):
     with open('setup_vars.ini') as f:
         lines = f.readlines()
-        if 'GNM_ENABLED=yes' in lines or 'GNM_ENABLED=yes\n' in lines:
-            GNM_ENABLED = True
+        if 'GNM_ENABLED=no' in lines or 'GNM_ENABLED=no\n' in lines:
+            GNM_ENABLED = False
 
 if GNM_ENABLED:
     ext_modules.append(gnm_module)
-    py_modules.append('gnm')
-
 
 if HAVE_NUMPY:
     ext_modules.append(array_module)
-    py_modules.append('gdalnumeric')
 
-packages = ["osgeo",]
+utils_package_root = 'gdal-utils'   # path for gdal-utils sources
+packages = find_packages(utils_package_root)
+packages = ['osgeo'] + packages
+package_dir = {'osgeo': 'osgeo', '': utils_package_root}
 
-readme = str(open('README.rst','rb').read())
+readme = open('README.rst', encoding='utf-8').read()
 
-name = 'GDAL'
-version = gdal_version
-author = "Frank Warmerdam"
-author_email = "warmerdam@pobox.com"
-maintainer = "Howard Butler"
-maintainer_email = "hobu.inc@gmail.com"
-description = "GDAL: Geospatial Data Abstraction Library"
-license = "MIT"
-url="http://www.gdal.org"
+name = 'storystream-gdal'
+author = 'Frank Warmerdam'
+author_email = 'warmerdam@pobox.com'
+maintainer = 'Howard Butler'
+maintainer_email = 'hobu.inc@gmail.com'
+description = 'GDAL: Geospatial Data Abstraction Library'
+license_type = 'MIT'
+url = 'http://www.gdal.org'
 
 classifiers = [
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: C',
-        'Programming Language :: C++',
-        'Topic :: Scientific/Engineering :: GIS',
-        'Topic :: Scientific/Engineering :: Information Analysis',
+    'Development Status :: 5 - Production/Stable',
+    'Intended Audience :: Developers',
+    'Intended Audience :: Science/Research',
+    'License :: OSI Approved :: MIT License',
+    'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: C',
+    'Programming Language :: C++',
+    'Topic :: Scientific/Engineering :: GIS',
+    'Topic :: Scientific/Engineering :: Information Analysis',
 
 ]
 
 
 if BUILD_FOR_CHEESESHOP:
-    data_files = [("osgeo/data/gdal", glob(os.path.join("../../data", "*")))]
+    data_files = [('osgeo/data/gdal', glob(os.path.join('../../data', '*')))]
 else:
     data_files = None
 
-exclude_package_data = {'':['GNUmakefile']}
+exclude_package_data = {'': ['GNUmakefile']}
 
-# Copy gdal/proj data.
-copy_data_tree('/usr/local/share/gdal', 'osgeo/gdal_data')
-copy_data_tree('/usr/local/share/proj', 'osgeo/proj_data')
+setup_kwargs = dict(
+    name=name,
+    version=gdal_version,
+    author=author,
+    author_email=author_email,
+    maintainer=maintainer,
+    maintainer_email=maintainer_email,
+    long_description=readme,
+    long_description_content_type='text/x-rst',
+    description=description,
+    license=license_type,
+    classifiers=classifiers,
+    packages=packages,
+    package_dir=package_dir,
+    url=url,
+    python_requires='>=3.6.0',
+    data_files=data_files,
+    ext_modules=ext_modules,
+    scripts=glob(utils_package_root + '/scripts/*.py'),
+    cmdclass={'build_ext': gdal_ext},
+    extras_require={'numpy': ['numpy > 1.0.0']},
+    zip_safe=False,
+    exclude_package_data=exclude_package_data
+)
 
-if HAVE_SETUPTOOLS:
-    setup( name = name,
-           version = gdal_version,
-           author = author,
-           author_email = author_email,
-           maintainer = maintainer,
-           maintainer_email = maintainer_email,
-           long_description = readme,
-           description = description,
-           license = license,
-           classifiers = classifiers,
-           py_modules = py_modules,
-           packages = packages,
-           url=url,
-           data_files = data_files,
-           zip_safe = False,
-           exclude_package_data = exclude_package_data,
-           cmdclass={'build_ext':gdal_ext},
-           ext_modules = ext_modules,
-           install_requires=['numpy=={}'.format(numpy.__version__)],
-           package_data={'osgeo': ['gdal_data/*', 'proj_data/*']},
-           **extra )
-else:
-    setup( name = name,
-           version = gdal_version,
-           author = author,
-           author_email = author_email,
-           maintainer = maintainer,
-           maintainer_email = maintainer_email,
-           long_description = readme,
-           description = description,
-           license = license,
-           classifiers = classifiers,
-           py_modules = py_modules,
-           packages = packages,
-           data_files = data_files,
-           url=url,
-           cmdclass={'build_ext':gdal_ext,
-                     'build_py': build_py,
-                     'build_scripts': build_scripts},
-           ext_modules = ext_modules )
+setup(**setup_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -328,7 +328,7 @@ package_dir = {'osgeo': 'osgeo', '': utils_package_root}
 
 readme = open('README.rst', encoding="utf-8").read()
 
-name = 'storystream-gdal'
+name = 'gdal'
 author = "Frank Warmerdam"
 author_email = "warmerdam@pobox.com"
 maintainer = "Howard Butler"

--- a/setup.py
+++ b/setup.py
@@ -23,22 +23,22 @@ from setuptools import Extension
 # but setuptools will be confused if it is made of several words like 'ccache g++'
 # and it will try to use only the first word.
 # See https://lists.osgeo.org/pipermail/gdal-dev/2016-July/044686.html
-# Note: in general when doing 'make', CXX will not be defined, unless it is defined as
+# Note: in general when doing "make", CXX will not be defined, unless it is defined as
 # an environment variable, but in that case it is the value of GDALmake.opt that
-# will be set, not the one from the environment that started 'make' !
+# will be set, not the one from the environment that started "make" !
 # If no CXX environment variable is defined, then the value of the CXX variable
 # in GDALmake.opt will not be set as an environment variable
 if 'CXX' in os.environ and os.environ['CXX'].strip().find(' ') >= 0:
     if os.environ['CXX'].strip().startswith('ccache ') and os.environ['CXX'].strip()[len('ccache '):].find(' ') < 0:
         os.environ['CXX'] = os.environ['CXX'].strip()[len('ccache '):]
     else:
-        print('WARNING: 'CXX=%s' was defined in the environment and contains more than one word. Unsetting it since that is incompatible of setuptools' % os.environ['CXX'])
+        print('WARNING: "CXX=%s" was defined in the environment and contains more than one word. Unsetting it since that is incompatible of setuptools' % os.environ['CXX'])
         del os.environ['CXX']
 if 'CC' in os.environ and os.environ['CC'].strip().find(' ') >= 0:
     if os.environ['CC'].strip().startswith('ccache ') and os.environ['CC'].strip()[len('ccache '):].find(' ') < 0:
         os.environ['CC'] = os.environ['CC'].strip()[len('ccache '):]
     else:
-        print('WARNING: 'CC=%s' was defined in the environment and contains more than one word. Unsetting it since that is incompatible of setuptools' % os.environ['CC'])
+        print('WARNING: "CC=%s" was defined in the environment and contains more than one word. Unsetting it since that is incompatible of setuptools' % os.environ['CC'])
         del os.environ['CC']
 
 # ---------------------------------------------------------------------------
@@ -80,12 +80,12 @@ try:
     # check version
     numpy_major = numpy.__version__.split('.')[0]
     if int(numpy_major) < 1:
-        print('numpy version must be > 1.0.0')
+        print("numpy version must be > 1.0.0")
         HAVE_NUMPY = False
     else:
         #  print ('numpy include', get_numpy_include())
         if get_numpy_include() == '.':
-            print('WARNING: numpy headers were not found!  Array support will not be enabled')
+            print("WARNING: numpy headers were not found!  Array support will not be enabled")
             HAVE_NUMPY = False
 except ImportError:
     print('WARNING: numpy not available!  Array support will not be enabled')
@@ -97,7 +97,7 @@ class gdal_config_error(Exception):
 
 def fetch_config(option, gdal_config='gdal-config'):
 
-    command = gdal_config + ' --%s' % option
+    command = gdal_config + " --%s" % option
 
     import subprocess
     command, args = command.split()[0], command.split()[1]
@@ -116,11 +116,11 @@ def fetch_config(option, gdal_config='gdal-config'):
 def supports_cxx11(compiler, compiler_flag=None):
     ret = False
     with open('gdal_python_cxx11_test.cpp', 'wt') as f:
-        f.write('''
+        f.write("""
 #if __cplusplus < 201103L
-#error 'C++11 required'
+#error "C++11 required"
 #endif
-int main () { return 0; }''')
+int main () { return 0; }""")
         f.close()
         extra_postargs = None
         if compiler_flag:
@@ -167,7 +167,7 @@ class gdal_ext(build_ext):
     user_options = build_ext.user_options[:]
     user_options.extend([
         ('gdal-config=', None,
-         'The name of the gdal-config binary and/or a full path to it'),
+         "The name of the gdal-config binary and/or a full path to it"),
     ])
 
     def initialize_options(self):
@@ -326,16 +326,16 @@ packages = find_packages(utils_package_root)
 packages = ['osgeo'] + packages
 package_dir = {'osgeo': 'osgeo', '': utils_package_root}
 
-readme = open('README.rst', encoding='utf-8').read()
+readme = open('README.rst', encoding="utf-8").read()
 
 name = 'storystream-gdal'
-author = 'Frank Warmerdam'
-author_email = 'warmerdam@pobox.com'
-maintainer = 'Howard Butler'
-maintainer_email = 'hobu.inc@gmail.com'
-description = 'GDAL: Geospatial Data Abstraction Library'
-license_type = 'MIT'
-url = 'http://www.gdal.org'
+author = "Frank Warmerdam"
+author_email = "warmerdam@pobox.com"
+maintainer = "Howard Butler"
+maintainer_email = "hobu.inc@gmail.com"
+description = "GDAL: Geospatial Data Abstraction Library"
+license_type = "MIT"
+url = "http://www.gdal.org"
 
 classifiers = [
     'Development Status :: 5 - Production/Stable',
@@ -353,7 +353,7 @@ classifiers = [
 
 
 if BUILD_FOR_CHEESESHOP:
-    data_files = [('osgeo/data/gdal', glob(os.path.join('../../data', '*')))]
+    data_files = [("osgeo/data/gdal", glob(os.path.join("../../data", "*")))]
 else:
     data_files = None
 


### PR DESCRIPTION
Test Plan for this is here: https://github.com/story-stream/python-packages/pull/7

Context:

Running `make` in this repo root allows us to generate the following:

```
➜  gdalmanylinux git:(feature/INF-177-gdal-upgrades) ✗ ls -l -1 wheels
storystream_gdal-3.5.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
storystream_gdal-3.5.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
storystream_gdal-3.5.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
storystream_gdal-3.5.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
```
They pip install on content-service on the corresponding architecture. I was testing with cp39-arm and cp311_x86. I will also test cp311-arm (for local dev) properly before submitting changes in the `python-packages` PR. This PR documents how the images are built that allows us to produce the wheels.

Other notes:
- We filter cpython versions to only include ones we support - this is to minimise python-packages codebuild time

Caution:
- These can take a long time to build completely for the first time.